### PR TITLE
Fix blocking when no frames available

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -290,7 +290,7 @@ unsigned synccom_port_has_incoming_data(struct synccom_port *port)
 	}
 	else {
 		spin_lock_irq(&port->queued_iframes_spinlock);
-		if ((port->bc_buffer[0] > 0) && (port->mbsize >= port->bc_buffer[0]))
+		if ((port->bc_buffer[0] > 0) && (port->mbsize >= port->bc_buffer[0]) && (port->running_frame_count > 0))
 			status = 1;
 		spin_unlock_irq(&port->queued_iframes_spinlock);
 	}


### PR DESCRIPTION
synccom_port_has_incoming_data would return true even when no full
frames have been received. Add condition that the frame counter must be
non-zero before unblocking the read() call to retrieve data.

Signed-off-by: Jonathan Haws <jhaws@sdl.usu.edu>